### PR TITLE
Korrigiere Position von Grafik zu Planar Separator Theorem.

### DIFF
--- a/Inoffizielles Skript.lyx
+++ b/Inoffizielles Skript.lyx
@@ -11427,7 +11427,7 @@ tikz{
 
 	
 \backslash
-draw[opacity=0] (-1,-2.5) rectangle (1,2.5);
+draw[opacity=0] (0,-2.5) rectangle (0,2.5);
 \end_layout
 
 \begin_layout Plain Layout


### PR DESCRIPTION
Die Grafik passte zuvor nicht auf die Seite und lief auf der rechten Seite über den Seitenrand hinaus.