### PR TITLE
Fix für Beweis 5-Listenfärbbarkeit

### DIFF
--- a/Inoffizielles Skript.lyx
+++ b/Inoffizielles Skript.lyx
@@ -9678,7 +9678,7 @@ Die Nachbarn
 
  Dreiecke sind.
  
-\begin_inset Formula $\left(G-v_{k}\right)\cup P\eqqcolon C'$
+\begin_inset Formula $\left(C-v_{k}\right)\cup P\eqqcolon C'$
 \end_inset
 
  ist wiederum ein Kreis.


### PR DESCRIPTION
(Originalbeweis siehe https://www.sciencedirect.com/journal/journal-of-combinatorial-theory-series-b/vol/62/issue/1, "Every Planar Graph Is 5-Choosable")